### PR TITLE
Adding support for cljs and cljc suffixes

### DIFF
--- a/cljfmt/cljfmt.go
+++ b/cljfmt/cljfmt.go
@@ -218,7 +218,9 @@ func (c *config) walkDir(path string) {
 		}
 		name := f.Name()
 		if strings.HasPrefix(name, ".") ||
-			!strings.HasSuffix(name, ".clj") {
+			!strings.HasSuffix(name, ".clj") &&
+				!strings.HasSuffix(name, ".cljs") &&
+				!strings.HasSuffix(name, ".cljc") {
 			return nil
 		}
 		return c.processFile(path, nil)


### PR DESCRIPTION
When specifying a path instead of reading from stdin, clojurescript files (with cljs suffix) and reader conditionals (with cljc suffix) are ignored, although formatting them works quite well.