### PR TITLE
Add support for :require-macros and :refer-macros

### DIFF
--- a/format/format_test.go
+++ b/format/format_test.go
@@ -100,10 +100,12 @@ func TestCustomIndent(t *testing.T) {
 
 	f := func(p *Printer) {
 		p.IndentOverrides = map[string]IndentStyle{
-			"delete":          IndentListBody,
-			"up":              IndentListBody,
-			"org.lib1/f":      IndentListBody,
-			"org.lib3/mycond": IndentCond0,
+			"delete":            IndentListBody,
+			"up":                IndentListBody,
+			"org.lib1/f":        IndentListBody,
+			"org.lib3/mycond":   IndentCond0,
+			"org.lib3/mymacro1": IndentLet,
+			"org.lib4/mymacro2": IndentLet,
 		}
 	}
 	testChangeCustom(t, file0, file1, f)

--- a/format/testdata/indent1.clj
+++ b/format/testdata/indent1.clj
@@ -1,7 +1,8 @@
 (ns myns
   (:require [org.lib1
              :as lib2]
-            [org.lib3 :refer [mycond]]))
+            [org.lib3 :refer [mycond] :refer-macros [mymacro1]])
+  (:require-macros [org.lib4 :refer [mymacro2]]))
 
 (locking x
   (dotimes [n 1000]
@@ -18,4 +19,8 @@
                                               (> z 7)
                                               (f 7
                                                  8
-                                                 9)))))))))))
+                                                 9))
+                                            (mymacro1 [a 10]
+                                                      "macro")
+                                            (mymacro2 [a 10]
+                                                      "macro"))))))))))

--- a/format/testdata/indent1_custom.clj
+++ b/format/testdata/indent1_custom.clj
@@ -1,7 +1,8 @@
 (ns myns
   (:require [org.lib1
              :as lib2]
-            [org.lib3 :refer [mycond]]))
+            [org.lib3 :refer [mycond] :refer-macros [mymacro1]])
+  (:require-macros [org.lib4 :refer [mymacro2]]))
 
 (locking x
   (dotimes [n 1000]
@@ -18,4 +19,8 @@
                     (> z 7)
                       (f 7
                          8
-                         9)))))))))))
+                         9))
+                  (mymacro1 [a 10]
+                    "macro")
+                  (mymacro2 [a 10]
+                    "macro"))))))))))

--- a/format/testdata/transform/unusedrequires_after.clj
+++ b/format/testdata/transform/unusedrequires_after.clj
@@ -1,7 +1,7 @@
 (ns a
   (:require [b]
             [c :refer :all]
-            [d :as e :refer [h]]
+            [d :as e :refer [h] :refer-macros [f3]]
             [foo-bar.x-y]
             [foo-bar2.x-y]
             [k :refer :all]
@@ -9,9 +9,12 @@
             [o :as p]
             [q :as r])
   (:import foo_bar.x_y.Z
-           [foo_bar2.x_y A B C]))
+           [foo_bar2.x_y A B C])
+  (:require-macros [w :as x]))
 
 (e/x #'p/x)
 (h 3)
 (b/x ::k1 ::q/k2 ::u/k3)
 #::r{:a 0 :b 1}
+(x/a 1)
+(f3 1)

--- a/format/testdata/transform/unusedrequires_before.clj
+++ b/format/testdata/transform/unusedrequires_before.clj
@@ -2,7 +2,7 @@
   (:require [b]
             [c :refer :all]
             [d :as e]
-            [d :as f :refer [g h i]]
+            [d :as f :refer [g h i] :refer-macros [f2 f3]]
             [foo-bar.x-y :as z]
             [foo-bar2.x-y :refer [z]]
             [j :refer [k l]])
@@ -12,9 +12,13 @@
   (:require [m :as n]
             [o :as p]
             [q :as r]
-            [myspec :as u]))
+            [myspec :as u])
+  (:require-macros [v]
+                   [w :as x]))
 
 (e/x #'p/x)
 (h 3)
 (b/x ::k1 ::q/k2 ::u/k3)
 #::r{:a 0 :b 1}
+(x/a 1)
+(f3 1)

--- a/format/transform.go
+++ b/format/transform.go
@@ -14,8 +14,8 @@ import (
 type Transform int
 
 const (
-	// TransformSortImportRequire sorts :import and :require declarations
-	// in ns blocks.
+	// TransformSortImportRequire sorts :import, :require, and :require-macros
+	// declarations in ns blocks.
 	TransformSortImportRequire Transform = iota
 
 	// TransformRemoveTrailingNewlines removes extra newlines following
@@ -145,7 +145,7 @@ func removeUnusedRequires(ns parse.Node, syms *symbolCache) {
 	nodes := children[:0]
 	for i := 0; i < len(children); i++ {
 		n := children[i]
-		if !goclj.FnFormKeyword(n, ":require") {
+		if !goclj.FnFormKeyword(n, ":require", ":require-macros") {
 			nodes = append(nodes, n)
 			continue
 		}
@@ -172,7 +172,7 @@ func removeUnusedRequires(ns parse.Node, syms *symbolCache) {
 
 func sortNS(ns parse.Node) {
 	for _, n := range ns.Children()[1:] {
-		if goclj.FnFormKeyword(n, ":require", ":import") {
+		if goclj.FnFormKeyword(n, ":require", ":require-macros", ":import") {
 			sortImportRequire(n.(*parse.ListNode))
 		}
 	}

--- a/format/unused.go
+++ b/format/unused.go
@@ -115,28 +115,12 @@ func (sc *symbolCache) unused(r *require) bool {
 			delete(r.as, as)
 		}
 	}
-	if r.origRefer != nil {
-		// If origRefer doesn't have any unused elements, leave it
-		// alone. Otherwise, rewrite it as a refer and handle below.
-		for _, n := range r.origRefer {
-			n, ok := n.(*parse.SymbolNode)
-			if !ok {
-				continue
-			}
-			if !sc.usesSym(n.Val) {
-				r.extractOrigRefer()
-				break
-			}
-		}
-	}
-	for ref := range r.refer {
-		if !sc.usesSym(ref) {
-			delete(r.refer, ref)
-		}
-	}
+	r.refer.removeUnused(sc)
+	r.referMacros.removeUnused(sc)
 	return !sc.usesNamespace(r.name) &&
 		!sc.usesRequireAsImport(r.name) &&
 		len(r.as) == 0 &&
 		!r.referAll &&
-		r.origRefer == nil && len(r.refer) == 0
+		r.refer.origRefer == nil && len(r.refer.refer) == 0 &&
+		r.referMacros.origRefer == nil && len(r.referMacros.refer) == 0
 }


### PR DESCRIPTION
`:require-macros`, `:refer-macros`, and `:use-macros` are used in clojure script to reference macros. They behave just like their non `-macros` equivalents, but must be managed separately.