### PR TITLE
Fix indentation in `for`, `doseq` bindings (including `:let`)

### DIFF
--- a/cljfmt/config.go
+++ b/cljfmt/config.go
@@ -135,6 +135,7 @@ var indentStyles = map[string]format.IndentStyle{
 	":list-body": format.IndentListBody,
 	":let":       format.IndentLet,
 	":letfn":     format.IndentLetfn,
+	":for":       format.IndentFor,
 	":deftype":   format.IndentDeftype,
 	":cond0":     format.IndentCond0,
 	":cond1":     format.IndentCond1,

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -38,6 +38,7 @@ func TestFixture(t *testing.T) {
 		"issue49",
 		"issue55",
 		"issue67",
+		"indent_for",
 	} {
 		t.Run(fixture, func(t *testing.T) {
 			testFixture(t, fixture+".clj")

--- a/format/testdata/indent_for.clj
+++ b/format/testdata/indent_for.clj
@@ -1,0 +1,9 @@
+(doseq [a
+          [0 1]
+        :let [b
+                (inc a)]])
+
+(for [a
+        [0 1]
+      :let [b
+              (inc a)]])


### PR DESCRIPTION
This PR is fixing indentation in `for` and `doseq` bindings, as well as nested `:let` bindings.

Fixes #76. Fixes #73.