### PR TITLE
Don't interpret (def x "blah") as having a docstring

### DIFF
--- a/format/format_test.go
+++ b/format/format_test.go
@@ -39,6 +39,7 @@ func TestFixture(t *testing.T) {
 		"issue55",
 		"issue67",
 		"indent_for",
+		"issue80",
 	} {
 		t.Run(fixture, func(t *testing.T) {
 			testFixture(t, fixture+".clj")

--- a/format/testdata/issue80.clj
+++ b/format/testdata/issue80.clj
@@ -1,0 +1,3 @@
+(def s
+  "This is not
+a docstring")


### PR DESCRIPTION
Fixes #80.