### PR TITLE
Add the enforce-ns-style transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ way (typically by running tests).
 
 Sort :import and :require declarations in ns blocks.
 
+### enforce-ns-style (default: on)
+
+Apply a few common `ns` style rules (based on [How to ns]):
+
+* Clauses use keywords (`:require`) rather than symbols (`require`)
+* Clauses are lists (`(:require ...)`) rather than vectors (`[:require ...]`)
+* There is a newline after `:require` or `:import`
+* For `:require` specifically:
+  - Each `require` is written as a vector, not a list
+  - Each `require`d namespace is written inside a vector (not a plain symbol)
+  - `:refer`ed and `:exclude`d items use vectors, not lists
+* For `:import` specifically:
+  - Each `import` is written as a list, not a vector
+  - Plain symbols become lists (`java.util.Date` becomes `(java.util Date)`)
+
+[How to ns]: https://stuartsierra.com/2016/clojure-how-to-ns.html
+
 ### remove-trailing-newlines (default: on)
 
 Remove extra newlines following sequence-like forms, so that parentheses are written on the same

--- a/cljfmt/cljfmt.go
+++ b/cljfmt/cljfmt.go
@@ -95,6 +95,8 @@ func (tf transformFlag) Set(v string) error {
 	switch v {
 	case "sort-import-require":
 		t = format.TransformSortImportRequire
+	case "enforce-ns-style":
+		t = format.TransformEnforceNSStyle
 	case "remove-trailing-newlines":
 		t = format.TransformRemoveTrailingNewlines
 	case "fix-defn-arglist-newline":

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -38,6 +38,15 @@ func TestChange(t *testing.T) {
 	}
 }
 
+func TestTransformsEnforceNSStyle(t *testing.T) {
+	testChangeTransforms(
+		t,
+		"transform/nsstyle_before.clj",
+		"transform/nsstyle_after.clj",
+		map[Transform]bool{TransformEnforceNSStyle: true},
+	)
+}
+
 func TestTransformsUseToRequire(t *testing.T) {
 	testChangeTransforms(
 		t,

--- a/format/require.go
+++ b/format/require.go
@@ -261,6 +261,7 @@ func (rl *requireList) render() []parse.Node {
 	} else {
 		nodes = append(nodes, &parse.KeywordNode{Val: ":require"})
 	}
+	nodes = append(nodes, newline)
 	for _, r := range rl.m {
 		for _, c := range r.comments.commentsAbove {
 			nodes = append(nodes, c, newline)

--- a/format/testdata/custom/indent1.clj
+++ b/format/testdata/custom/indent1.clj
@@ -1,8 +1,10 @@
 (ns myns
-  (:require [org.lib1
-             :as lib2]
-            [org.lib3 :refer [mycond] :refer-macros [mymacro1]])
-  (:require-macros [org.lib4 :refer [mymacro2]]))
+  (:require
+    [org.lib1
+     :as lib2]
+    [org.lib3 :refer [mycond] :refer-macros [mymacro1]])
+  (:require-macros
+    [org.lib4 :refer [mymacro2]]))
 
 (locking x
   (dotimes [n 1000]

--- a/format/testdata/custom/indent1_custom.clj
+++ b/format/testdata/custom/indent1_custom.clj
@@ -1,8 +1,10 @@
 (ns myns
-  (:require [org.lib1
-             :as lib2]
-            [org.lib3 :refer [mycond] :refer-macros [mymacro1]])
-  (:require-macros [org.lib4 :refer [mymacro2]]))
+  (:require
+    [org.lib1
+     :as lib2]
+    [org.lib3 :refer [mycond] :refer-macros [mymacro1]])
+  (:require-macros
+    [org.lib4 :refer [mymacro2]]))
 
 (locking x
   (dotimes [n 1000]

--- a/format/testdata/custom/transforms_after.clj
+++ b/format/testdata/custom/transforms_after.clj
@@ -1,6 +1,7 @@
 (ns a
-  (:require z
-            a))
+  (:require
+    [z]
+    [a]))
 
 (defn foo
   [x] (inc x))

--- a/format/testdata/custom/transforms_before.clj
+++ b/format/testdata/custom/transforms_before.clj
@@ -1,6 +1,7 @@
 (ns a
-  (:require z
-            a))
+  (:require
+    [z]
+    [a]))
 
 
 (defn foo

--- a/format/testdata/custom/unusedrequires_after.clj
+++ b/format/testdata/custom/unusedrequires_after.clj
@@ -1,16 +1,19 @@
 (ns a
-  (:require [b]
-            [c :refer :all]
-            [d :as e :refer [h] :refer-macros [f3]]
-            [foo-bar.x-y]
-            [foo-bar2.x-y]
-            [k :refer :all]
-            [myspec :as u]
-            [o :as p]
-            [q :as r])
-  (:import foo_bar.x_y.Z
-           [foo_bar2.x_y A B C])
-  (:require-macros [w :as x]))
+  (:require
+    [b]
+    [c :refer :all]
+    [d :as e :refer [h] :refer-macros [f3]]
+    [foo-bar.x-y]
+    [foo-bar2.x-y]
+    [k :refer :all]
+    [myspec :as u]
+    [o :as p]
+    [q :as r])
+  (:import
+    (foo_bar.x_y Z)
+    (foo_bar2.x_y A B C))
+  (:require-macros
+    [w :as x]))
 
 (e/x #'p/x)
 (h 3)

--- a/format/testdata/custom/unusedrequires_before.clj
+++ b/format/testdata/custom/unusedrequires_before.clj
@@ -1,20 +1,24 @@
 (ns a
-  (:require [b]
-            [c :refer :all]
-            [d :as e]
-            [d :as f :refer [g h i] :refer-macros [f2 f3]]
-            [foo-bar.x-y :as z]
-            [foo-bar2.x-y :refer [z]]
-            [j :refer [k l]])
+  (:require
+    [b]
+    [c :refer :all]
+    [d :as e]
+    [d :as f :refer [g h i] :refer-macros [f2 f3]]
+    [foo-bar.x-y :as z]
+    [foo-bar2.x-y :refer [z]]
+    [j :refer [k l]])
   (:use k)
-  (:import foo_bar.x_y.Z
-           [foo_bar2.x_y A B C])
-  (:require [m :as n]
-            [o :as p]
-            [q :as r]
-            [myspec :as u])
-  (:require-macros [v]
-                   [w :as x]))
+  (:import
+    foo_bar.x_y.Z
+    (foo_bar2.x_y A B C))
+  (:require
+    [m :as n]
+    [o :as p]
+    [q :as r]
+    [myspec :as u])
+  (:require-macros
+    [v]
+    [w :as x]))
 
 (e/x #'p/x)
 (h 3)

--- a/format/testdata/custom/unusedrequiresempty_after.clj
+++ b/format/testdata/custom/unusedrequiresempty_after.clj
@@ -1,5 +1,6 @@
 (ns a
-  (:import [foo.bar Baz]))
+  (:import
+    (foo.bar Baz)))
 
 (xyz)
 (Baz.)

--- a/format/testdata/custom/unusedrequiresempty_before.clj
+++ b/format/testdata/custom/unusedrequiresempty_before.clj
@@ -1,7 +1,7 @@
 (ns a
   (:require [b :refer [c d e]]
             [f :as g])
-  (:import [foo.bar Baz]))
+  (:import (foo.bar Baz)))
 
 (xyz)
 (Baz.)

--- a/format/testdata/custom/use2require_after.clj
+++ b/format/testdata/custom/use2require_after.clj
@@ -1,21 +1,23 @@
 (ns a
-  (:require ; b
-            ; c
-            ; f
-            ; e
-            ; h
-            [a :as b]
-            [a :as g :refer [d e f h]]
-            [a [b :as c]] ; d
-            [c :as d :refer :all]
-            ; i
-            [i]
-            [q0 :as q1]
-            [x :refer [z
-                       y]] ; g
-            [z :refer :all]
-            #{blah} ; a
-            ; below0
-            ; below1
-            )
-  (:use 3))
+  (:require
+    ; b
+    ; c
+    ; f
+    ; e
+    ; h
+    [a :as b]
+    [a :as g :refer [d e f h]]
+    [a [b :as c]] ; d
+    [c :as d :refer :all]
+    ; i
+    [i]
+    [q0 :as q1]
+    [x :refer [z
+               y]] ; g
+    [z :refer :all]
+    #{blah} ; a
+    ; below0
+    ; below1
+    )
+  (:use
+    3))

--- a/format/testdata/custom/use2require_before.clj
+++ b/format/testdata/custom/use2require_before.clj
@@ -1,24 +1,27 @@
 (ns a
-  (:require #{blah} ; a
-            ; b
-            ; c
-            a
-            [a [b :as c]] ; d
-            [a :as b] ; e
-            (c :as d)
-            ; f
-            [a :refer [f e
-                       d]]
-            ; below0
-            )
-  (:use c
-        (x :only [z
-                  y]) ; g
-        [q0 :as q1]
-        [z]
-        3
-        ; below1
-        )
-  (:require [a :as g :refer [h]] ; h
-            ; i
-            i))
+  (:require
+    #{blah} ; a
+    ; b
+    ; c
+    a
+    [a [b :as c]] ; d
+    [a :as b] ; e
+    (c :as d)
+    ; f
+    [a :refer [f e
+               d]]
+    ; below0
+    )
+  (:use
+    c
+    (x :only [z
+              y]) ; g
+    [q0 :as q1]
+    [z]
+    3
+    ; below1
+    )
+  (:require
+    [a :as g :refer [h]] ; h
+    ; i
+    i))

--- a/format/testdata/issue7_after.clj
+++ b/format/testdata/issue7_after.clj
@@ -1,9 +1,11 @@
 (ns foobar
   "hello there"
-  (:require [a]
-            [b :as blah]
-            [c :refer :all])
-  (:import [a.b.c Bar]
-           a.b.c.Foo
-           [x.y.z Bar Baz]
-           x.y.z.Foo))
+  (:require
+    [a]
+    [b :as blah]
+    [c :refer :all])
+  (:import
+    (a.b.c Bar)
+    (a.b.c Foo)
+    (x.y.z Foo)
+    (x.y.z Bar Baz)))

--- a/format/testdata/issue7_before.clj
+++ b/format/testdata/issue7_before.clj
@@ -1,9 +1,11 @@
 (ns foobar
   "hello there"
-  (:require [c :refer :all]
-            [a]
-            [b :as blah])
-  (:import [a.b.c Bar]
-           a.b.c.Foo
-           x.y.z.Foo
-           [x.y.z Bar Baz]))
+  (:require
+    [c :refer :all]
+    [a]
+    [b :as blah])
+  (:import
+    (a.b.c Bar)
+    a.b.c.Foo
+    x.y.z.Foo
+    (x.y.z Bar Baz)))

--- a/format/testdata/require_after.clj
+++ b/format/testdata/require_after.clj
@@ -1,10 +1,12 @@
 (ns foo.bar
-  (:require ; a
-            [a :refer [x y z]] ; blah
-            ; z
-            (z :as z) ; another
-            ; after
-            )
-  (:import java.io.DataInputStream
-           java.io.File
-           [java.util.zip GZIPInputStream]))
+  (:require
+    ; a
+    [a :refer [x y z]] ; blah
+    ; z
+    [z :as z] ; another
+    ; after
+    )
+  (:import
+    (java.io File)
+    (java.io DataInputStream)
+    (java.util.zip GZIPInputStream)))

--- a/format/testdata/require_before.clj
+++ b/format/testdata/require_before.clj
@@ -1,11 +1,13 @@
 (ns foo.bar
-  (:require ; z
-            (z :as z) ; another
-            ; a
-            [a :refer [x y z]] ; blah
-            ; after
-            )
-  (:import java.io.File
-           [java.util.zip GZIPInputStream]
-           java.io.DataInputStream
-           ))
+  (:require
+    ; z
+    [z :as z] ; another
+    ; a
+    [a :refer [x y z]] ; blah
+    ; after
+    )
+  (:import
+    java.io.File
+    (java.util.zip GZIPInputStream)
+    java.io.DataInputStream
+    ))

--- a/format/testdata/simple1.clj
+++ b/format/testdata/simple1.clj
@@ -1,6 +1,7 @@
 (ns foo.bar
-  (:require [clojure.set :as set]
-            [clojure.string :as string]))
+  (:require
+    [clojure.set :as set]
+    [clojure.string :as string]))
 
 (defn throw-str
   "Throws a RuntimeException, str-ing together its arguments."

--- a/format/testdata/transform/nsstyle_after.clj
+++ b/format/testdata/transform/nsstyle_after.clj
@@ -1,0 +1,6 @@
+(ns my-ns
+  (:require
+    [clojure.string :refer [blank? capitalize ends-with?]]
+    [com.example.server])
+  (:import
+    (java.util Date)))

--- a/format/testdata/transform/nsstyle_before.clj
+++ b/format/testdata/transform/nsstyle_before.clj
@@ -1,0 +1,4 @@
+(ns my-ns
+  [require (clojure.string :refer (blank? capitalize ends-with?))
+   com.example.server]
+  [import [java.util Date]])


### PR DESCRIPTION
This applies common NS style rules from "How to ns".

See the updated README for an exact list of the changes that it does. (I just went with the ones that were really easy.)

@jwhitbeck please review the changes that this implements (no need to review the code itself). You can see this applied to our internal codebase on the branch `caleb.cljfmt-how-to-ns`. (Right now we're just agreeing about the behavior we want; actually rolling out this change internally will be a job for later.)

Fixes #68.