### PR TITLE
Add :for to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ Examples of builtins that use `:let` by default are `binding`, `dotimes`,
   (* x y))
 ```
 
+**:for** is for for-like forms. This is similar to `:let`, but
+additionally it supports having a `:let` clause with let-like binding vector
+formatted accordingly.
+
+Examples of builtins that use `:for` by default are `for`, and `doseq`.
+
+``` clojure
+(for [x
+        (range 5)
+      :let [y
+              (- 100 x)]
+  (* x y))
+```
+
 **:letfn** is used for indenting letfn, where the binding vector contains
 function bodies that themselves should be indented as `:list-body`.
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ aligned under the second element of the list.
 indented by two spaces.
 
 Examples of builtins which use `:list-body` indentation by default are `fn`,
-`for`, `when`, and most macros beginning with `def`.
+`when`, and most macros beginning with `def`.
 
 ``` clojure
 (when-not (zero? x)
@@ -203,7 +203,7 @@ Examples of builtins that use `:let` by default are `binding`, `dotimes`,
 additionally it supports having a `:let` clause with let-like binding vector
 formatted accordingly.
 
-Examples of builtins that use `:for` by default are `for`, and `doseq`.
+The builtins that use `:for` by default are `for` and `doseq`.
 
 ``` clojure
 (for [x


### PR DESCRIPTION
This PR adds section of information on `:for` formatting I introduced earlier.