### PR TITLE
Fix thread-first overrides

### DIFF
--- a/cljfmt/cljfmt.go
+++ b/cljfmt/cljfmt.go
@@ -192,6 +192,7 @@ func (c *config) processFile(filename string, in io.Reader) error {
 	p := format.NewPrinter(&buf2)
 	p.IndentChar = ' '
 	p.IndentOverrides = c.indentOverrides
+	p.ThreadFirstStyleOverrides = c.threadFirstOverrides
 	p.Transforms = c.transforms
 	if err := p.PrintTree(t); err != nil {
 		return err

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -126,6 +126,16 @@ func TestIssue41(t *testing.T) {
 	testChangeCustom(t, file, file, f)
 }
 
+func TestThreadFirstOverride(t *testing.T) {
+	const file = "custom/threadfirst.clj"
+	f := func(p *Printer) {
+		p.ThreadFirstStyleOverrides = map[string]ThreadFirstStyle{
+			"-?>": ThreadFirstNormal,
+		}
+	}
+	testChangeCustom(t, file, file, f)
+}
+
 func testFixture(t *testing.T, filename string) {
 	testChange(t, filename, filename)
 }

--- a/format/testdata/custom/threadfirst.clj
+++ b/format/testdata/custom/threadfirst.clj
@@ -1,0 +1,8 @@
+(-?> a
+     b
+     (cond->
+       "1"
+         (foo 1)
+       "2"
+         (foo 2)
+       :default))


### PR DESCRIPTION
Fixes https://github.com/cespare/goclj/issues/92.

The test only checks the correctness of the format but there is no test showing that config is not propagated to the printer.