### PR TITLE
Allow setting config path via CLJFMT_CONFIG_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,13 @@ Use simple heuristics to remove some probably-unused :require statements:
 
 ## Cljfmt configuration
 
-You can optionally use a config file at `$HOME/.cljfmt` (override with `-c`).
+Cljfmt can optionally use a config file in one of these locations (in order
+of precedence):
+
+1. The path specified by the `-c` CLI argument
+2. The path specified by the `CLJFMT_CONFIG_PATH` environment variable
+3. `$HOME/.cljfmt`
+
 This is a Clojure file containing a single map of options. Here's an example:
 
 ```

--- a/cljfmt/cljfmt.go
+++ b/cljfmt/cljfmt.go
@@ -38,9 +38,8 @@ type config struct {
 func main() {
 	log.SetFlags(0)
 	log.SetPrefix("cljfmt: ")
-	var configFile pathFlag
-	if home, ok := os.LookupEnv("HOME"); ok {
-		configFile.p = filepath.Join(home, ".cljfmt")
+	configFile := pathFlag{
+		p: defaultConfigPath(),
 	}
 	conf := config{
 		transforms: make(map[format.Transform]bool),
@@ -83,6 +82,16 @@ func main() {
 			log.Fatal(err)
 		}
 	}
+}
+
+func defaultConfigPath() string {
+	if path, ok := os.LookupEnv("CLJFMT_CONFIG_PATH"); ok {
+		return path
+	}
+	if home, ok := os.LookupEnv("HOME"); ok {
+		return filepath.Join(home, ".cljfmt")
+	}
+	return ""
 }
 
 type transformFlag struct {


### PR DESCRIPTION
This change allows you to set the path to the config via an environment variable.