### PR TITLE
Run cljfmt over .edn files

### DIFF
--- a/cljfmt/cljfmt.go
+++ b/cljfmt/cljfmt.go
@@ -234,7 +234,7 @@ func (c *config) walkDir(path string) {
 		if strings.HasPrefix(name, ".") {
 			return nil
 		}
-		for _, ext := range []string{".clj", ".cljs", ".cljc"} {
+		for _, ext := range []string{".clj", ".cljs", ".cljc", ".edn"} {
 			if strings.HasSuffix(name, ext) {
 				return c.processFile(path, nil)
 			}


### PR DESCRIPTION
Cljfmt transformations appear to apply correctly to edn, which is a subset of Clojure syntax. This PR proposes to turn on edn formatting by default.